### PR TITLE
Added import of Foundation

### DIFF
--- a/Sources/Value.swift
+++ b/Sources/Value.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2017 PureSwift. All rights reserved.
 //
 
+import Foundation
+
 /// Constant value used in predicate expressions.
 public enum Value {
     


### PR DESCRIPTION
When incorporating the package into applications, it would not compile as the Value.swift file references Foundation classes, but didn't import the framework.