### PR TITLE
Declare conformance to `Sendable`

### DIFF
--- a/Sources/Comparison.swift
+++ b/Sources/Comparison.swift
@@ -7,7 +7,7 @@
 //
 
 /// Comparison Predicate
-public struct Comparison: Equatable, Hashable, Codable, Sendable {
+public struct Comparison: Equatable, Hashable, Codable {
     
     public var left: Expression
     
@@ -37,13 +37,13 @@ public struct Comparison: Equatable, Hashable, Codable, Sendable {
 
 public extension Comparison {
 
-    enum Modifier: String, Codable, Sendable {
+    enum Modifier: String, Codable {
         
         case all        = "ALL"
         case any        = "ANY"
     }
     
-    enum Option: String, Codable, Sendable {
+    enum Option: String, Codable {
         
         /// A case-insensitive predicate.
         case caseInsensitive        = "c"
@@ -59,7 +59,7 @@ public extension Comparison {
         case localeSensitive        = "l"
     }
     
-    enum Operator: String, Codable, Sendable {
+    enum Operator: String, Codable {
         
         /// A less-than predicate.
         case lessThan               = "<"
@@ -303,3 +303,12 @@ public extension String {
         return .comparison(comparison)
     }
 }
+
+#if swift(>=5.5)
+
+extension Comparison: Sendable {}
+extension Comparison.Modifier: Sendable {}
+extension Comparison.Option: Sendable {}
+extension Comparison.Operator: Sendable {}
+
+#endif

--- a/Sources/Comparison.swift
+++ b/Sources/Comparison.swift
@@ -7,7 +7,7 @@
 //
 
 /// Comparison Predicate
-public struct Comparison: Equatable, Hashable, Codable {
+public struct Comparison: Equatable, Hashable, Codable, Sendable {
     
     public var left: Expression
     
@@ -37,13 +37,13 @@ public struct Comparison: Equatable, Hashable, Codable {
 
 public extension Comparison {
 
-    enum Modifier: String, Codable {
+    enum Modifier: String, Codable, Sendable {
         
         case all        = "ALL"
         case any        = "ANY"
     }
     
-    enum Option: String, Codable {
+    enum Option: String, Codable, Sendable {
         
         /// A case-insensitive predicate.
         case caseInsensitive        = "c"
@@ -59,7 +59,7 @@ public extension Comparison {
         case localeSensitive        = "l"
     }
     
-    enum Operator: String, Codable {
+    enum Operator: String, Codable, Sendable {
         
         /// A less-than predicate.
         case lessThan               = "<"

--- a/Sources/Comparison.swift
+++ b/Sources/Comparison.swift
@@ -304,7 +304,7 @@ public extension String {
     }
 }
 
-#if swift(>=5.5)
+#if swift(>=5.7)
 
 extension Comparison: Sendable {}
 extension Comparison.Modifier: Sendable {}

--- a/Sources/Compound.swift
+++ b/Sources/Compound.swift
@@ -7,7 +7,7 @@
 //
 
 /// Predicate type used to represent logical “gate” operations (AND/OR/NOT) and comparison operations.
-public indirect enum Compound: Equatable, Hashable {
+public indirect enum Compound: Equatable, Hashable, Sendable {
     
     case and([Predicate])
     case or([Predicate])
@@ -42,7 +42,7 @@ public extension Compound {
 public extension Compound {
     
     /// Possible Compund Predicate types.
-    enum Logical​Type: String, Codable {
+    enum Logical​Type: String, Codable, Sendable {
         
         /// A logical NOT predicate.
         case not = "NOT"
@@ -104,7 +104,7 @@ extension Compound: CustomStringConvertible {
 
 extension Compound: Codable {
     
-    internal enum CodingKeys: String, CodingKey {
+    internal enum CodingKeys: String, CodingKey, Sendable {
         
         case type
         case predicates

--- a/Sources/Compound.swift
+++ b/Sources/Compound.swift
@@ -166,7 +166,7 @@ public prefix func ! (rhs: Predicate) -> Predicate {
     return .compound(.not(rhs))
 }
 
-#if swift(>=5.5)
+#if swift(>=5.7)
 
 extension Compound: Sendable {}
 extension Compound.Logical​Type: Sendable {}

--- a/Sources/Compound.swift
+++ b/Sources/Compound.swift
@@ -7,7 +7,7 @@
 //
 
 /// Predicate type used to represent logical “gate” operations (AND/OR/NOT) and comparison operations.
-public indirect enum Compound: Equatable, Hashable, Sendable {
+public indirect enum Compound: Equatable, Hashable {
     
     case and([Predicate])
     case or([Predicate])
@@ -42,7 +42,7 @@ public extension Compound {
 public extension Compound {
     
     /// Possible Compund Predicate types.
-    enum Logical​Type: String, Codable, Sendable {
+    enum Logical​Type: String, Codable {
         
         /// A logical NOT predicate.
         case not = "NOT"
@@ -104,7 +104,7 @@ extension Compound: CustomStringConvertible {
 
 extension Compound: Codable {
     
-    internal enum CodingKeys: String, CodingKey, Sendable {
+    internal enum CodingKeys: String, CodingKey {
         
         case type
         case predicates
@@ -165,3 +165,10 @@ public func || (lhs: Predicate, rhs: [Predicate]) -> Predicate {
 public prefix func ! (rhs: Predicate) -> Predicate {
     return .compound(.not(rhs))
 }
+
+#if swift(>=5.5)
+
+extension Compound: Sendable {}
+extension Compound.Logical​Type: Sendable {}
+
+#endif

--- a/Sources/Context.swift
+++ b/Sources/Context.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Context for evaluating predicates.
-public struct PredicateContext: Equatable, Hashable, Sendable {
+public struct PredicateContext: Equatable, Hashable {
     
     public typealias KeyPath = PredicateKeyPath
     
@@ -107,3 +107,9 @@ extension PredicateContext: PredicateEvaluatable {
         return try lhs.compare(rhs, operator: predicate.type, modifier: predicate.modifier, options: predicate.options)
     }
 }
+
+#if swift(>=5.5)
+
+extension PredicateContext: Sendable {}
+
+#endif

--- a/Sources/Context.swift
+++ b/Sources/Context.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Context for evaluating predicates.
-public struct PredicateContext: Equatable, Hashable {
+public struct PredicateContext: Equatable, Hashable, Sendable {
     
     public typealias KeyPath = PredicateKeyPath
     

--- a/Sources/Context.swift
+++ b/Sources/Context.swift
@@ -108,7 +108,7 @@ extension PredicateContext: PredicateEvaluatable {
     }
 }
 
-#if swift(>=5.5)
+#if swift(>=5.7)
 
 extension PredicateContext: Sendable {}
 

--- a/Sources/Error.swift
+++ b/Sources/Error.swift
@@ -13,7 +13,7 @@ public enum PredicateError: Error {
     case invalidComparison(Value, Value, Comparison.Operator, Comparison.Modifier?, Set<Comparison.Option>)
 }
 
-#if swift(>=5.5)
+#if swift(>=5.7)
 
 extension PredicateError: Sendable {}
 

--- a/Sources/Error.swift
+++ b/Sources/Error.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum PredicateError: Error {
+public enum PredicateError: Error, Sendable {
     
     case invalidKeyPath(PredicateKeyPath)
     case invalidComparison(Value, Value, Comparison.Operator, Comparison.Modifier?, Set<Comparison.Option>)

--- a/Sources/Error.swift
+++ b/Sources/Error.swift
@@ -7,8 +7,14 @@
 
 import Foundation
 
-public enum PredicateError: Error, Sendable {
+public enum PredicateError: Error {
     
     case invalidKeyPath(PredicateKeyPath)
     case invalidComparison(Value, Value, Comparison.Operator, Comparison.Modifier?, Set<Comparison.Option>)
 }
+
+#if swift(>=5.5)
+
+extension PredicateError: Sendable {}
+
+#endif

--- a/Sources/Expression.swift
+++ b/Sources/Expression.swift
@@ -7,7 +7,7 @@
 //
 
 /// Used to represent expressions in a predicate.
-public enum Expression: Equatable, Hashable, Sendable {
+public enum Expression: Equatable, Hashable {
     
     /// Expression that represents a given constant value.
     case value(Value)
@@ -17,7 +17,7 @@ public enum Expression: Equatable, Hashable, Sendable {
 }
 
 /// Type of predicate expression.
-public enum ExpressionType: String, Codable, Sendable {
+public enum ExpressionType: String, Codable {
     
     case value
     case keyPath
@@ -50,7 +50,7 @@ extension Expression: CustomStringConvertible {
 
 extension Expression: Codable {
     
-    internal enum CodingKeys: String, CodingKey, Sendable {
+    internal enum CodingKeys: String, CodingKey {
         
         case type
         case expression
@@ -107,3 +107,10 @@ public extension Expression {
         return .comparison(comparison)
     }
 }
+
+#if swift(>=5.5)
+
+extension Expression: Sendable {}
+extension ExpressionType: Sendable {}
+
+#endif

--- a/Sources/Expression.swift
+++ b/Sources/Expression.swift
@@ -108,7 +108,7 @@ public extension Expression {
     }
 }
 
-#if swift(>=5.5)
+#if swift(>=5.7)
 
 extension Expression: Sendable {}
 extension ExpressionType: Sendable {}

--- a/Sources/Expression.swift
+++ b/Sources/Expression.swift
@@ -7,7 +7,7 @@
 //
 
 /// Used to represent expressions in a predicate.
-public enum Expression: Equatable, Hashable {
+public enum Expression: Equatable, Hashable, Sendable {
     
     /// Expression that represents a given constant value.
     case value(Value)
@@ -17,7 +17,7 @@ public enum Expression: Equatable, Hashable {
 }
 
 /// Type of predicate expression.
-public enum ExpressionType: String, Codable {
+public enum ExpressionType: String, Codable, Sendable {
     
     case value
     case keyPath
@@ -50,7 +50,7 @@ extension Expression: CustomStringConvertible {
 
 extension Expression: Codable {
     
-    internal enum CodingKeys: String, CodingKey {
+    internal enum CodingKeys: String, CodingKey, Sendable {
         
         case type
         case expression

--- a/Sources/KeyPath.swift
+++ b/Sources/KeyPath.swift
@@ -185,7 +185,7 @@ extension PredicateKeyPath.Operator: CustomStringConvertible {
     }
 }
 
-#if swift(>=5.5)
+#if swift(>=5.7)
 
 extension PredicateKeyPath: Sendable {}
 extension PredicateKeyPath.Key: Sendable {}

--- a/Sources/KeyPath.swift
+++ b/Sources/KeyPath.swift
@@ -6,7 +6,7 @@
 //
 
 /// Key Path
-public struct PredicateKeyPath: Equatable, Hashable, Sendable {
+public struct PredicateKeyPath: Equatable, Hashable {
     
     public var keys: [Key]
     
@@ -116,7 +116,7 @@ extension PredicateKeyPath: ExpressibleByArrayLiteral {
 
 public extension PredicateKeyPath {
     
-    enum Key: Equatable, Hashable, Sendable {
+    enum Key: Equatable, Hashable {
         case property(String)
         case index(UInt)
         case `operator`(Operator)
@@ -162,7 +162,7 @@ extension PredicateKeyPath.Key: RawRepresentable {
 
 public extension PredicateKeyPath {
     
-    enum Operator: String, Sendable {
+    enum Operator: String {
         case count      = "@count"
         case sum        = "@sum"
         case min        = "@min"
@@ -184,3 +184,11 @@ extension PredicateKeyPath.Operator: CustomStringConvertible {
         return rawValue
     }
 }
+
+#if swift(>=5.5)
+
+extension PredicateKeyPath: Sendable {}
+extension PredicateKeyPath.Key: Sendable {}
+extension PredicateKeyPath.Operator: Sendable {}
+
+#endif

--- a/Sources/KeyPath.swift
+++ b/Sources/KeyPath.swift
@@ -6,7 +6,7 @@
 //
 
 /// Key Path
-public struct PredicateKeyPath: Equatable, Hashable {
+public struct PredicateKeyPath: Equatable, Hashable, Sendable {
     
     public var keys: [Key]
     
@@ -116,7 +116,7 @@ extension PredicateKeyPath: ExpressibleByArrayLiteral {
 
 public extension PredicateKeyPath {
     
-    enum Key: Equatable, Hashable {
+    enum Key: Equatable, Hashable, Sendable {
         case property(String)
         case index(UInt)
         case `operator`(Operator)
@@ -162,7 +162,7 @@ extension PredicateKeyPath.Key: RawRepresentable {
 
 public extension PredicateKeyPath {
     
-    enum Operator: String {
+    enum Operator: String, Sendable {
         case count      = "@count"
         case sum        = "@sum"
         case min        = "@min"

--- a/Sources/Predicate.swift
+++ b/Sources/Predicate.swift
@@ -8,7 +8,7 @@
 
 /// You use predicates to represent logical conditions,
 /// used for describing objects in persistent stores and in-memory filtering of objects.
-public enum Predicate: Equatable, Hashable, Sendable {
+public enum Predicate: Equatable, Hashable {
     
     case comparison(Comparison)
     case compound(Compound)
@@ -16,7 +16,7 @@ public enum Predicate: Equatable, Hashable, Sendable {
 }
 
 /// Predicate Type
-public enum PredicateType: String, Codable, Sendable {
+public enum PredicateType: String, Codable {
     
     case comparison
     case compound
@@ -53,7 +53,7 @@ extension Predicate: CustomStringConvertible {
 
 extension Predicate: Codable {
     
-    internal enum CodingKeys: String, CodingKey, Sendable {
+    internal enum CodingKeys: String, CodingKey {
         
         case type
         case predicate
@@ -92,3 +92,10 @@ extension Predicate: Codable {
         }
     }
 }
+
+#if swift(>=5.5)
+
+extension Predicate: Sendable {}
+extension PredicateType: Sendable {}
+
+#endif

--- a/Sources/Predicate.swift
+++ b/Sources/Predicate.swift
@@ -93,7 +93,7 @@ extension Predicate: Codable {
     }
 }
 
-#if swift(>=5.5)
+#if swift(>=5.7)
 
 extension Predicate: Sendable {}
 extension PredicateType: Sendable {}

--- a/Sources/Predicate.swift
+++ b/Sources/Predicate.swift
@@ -8,7 +8,7 @@
 
 /// You use predicates to represent logical conditions,
 /// used for describing objects in persistent stores and in-memory filtering of objects.
-public enum Predicate: Equatable, Hashable {
+public enum Predicate: Equatable, Hashable, Sendable {
     
     case comparison(Comparison)
     case compound(Compound)
@@ -16,7 +16,7 @@ public enum Predicate: Equatable, Hashable {
 }
 
 /// Predicate Type
-public enum PredicateType: String, Codable {
+public enum PredicateType: String, Codable, Sendable {
     
     case comparison
     case compound
@@ -53,7 +53,7 @@ extension Predicate: CustomStringConvertible {
 
 extension Predicate: Codable {
     
-    internal enum CodingKeys: String, CodingKey {
+    internal enum CodingKeys: String, CodingKey, Sendable {
         
         case type
         case predicate

--- a/Sources/Value.swift
+++ b/Sources/Value.swift
@@ -319,7 +319,7 @@ extension Sequence where Element: PredicateValue {
     public var predicateValue: Value { return .collection(self.map({ $0.predicateValue })) }
 }
 
-#if swift(>=5.5)
+#if swift(>=5.7)
 
 extension Value: Sendable {}
 extension ValueType: Sendable {}

--- a/Sources/Value.swift
+++ b/Sources/Value.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Constant value used in predicate expressions.
-public enum Value: Equatable, Hashable {
+public enum Value: Equatable, Hashable, Sendable {
     
     case null
     case string(String)
@@ -33,7 +33,7 @@ public enum Value: Equatable, Hashable {
 // MARK: - Supporting Types
 
 /// Predicate Value Type
-public enum ValueType: String, Codable {
+public enum ValueType: String, Codable, Sendable {
     
     case null
     case string
@@ -129,7 +129,7 @@ extension Value: CustomStringConvertible {
 
 extension Value: Codable {
     
-    internal enum CodingKeys: String, CodingKey {
+    internal enum CodingKeys: String, CodingKey, Sendable {
         
         case type
         case value

--- a/Sources/Value.swift
+++ b/Sources/Value.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Constant value used in predicate expressions.
-public enum Value: Equatable, Hashable, Sendable {
+public enum Value: Equatable, Hashable {
     
     case null
     case string(String)
@@ -33,7 +33,7 @@ public enum Value: Equatable, Hashable, Sendable {
 // MARK: - Supporting Types
 
 /// Predicate Value Type
-public enum ValueType: String, Codable, Sendable {
+public enum ValueType: String, Codable {
     
     case null
     case string
@@ -129,7 +129,7 @@ extension Value: CustomStringConvertible {
 
 extension Value: Codable {
     
-    internal enum CodingKeys: String, CodingKey, Sendable {
+    internal enum CodingKeys: String, CodingKey {
         
         case type
         case value
@@ -318,3 +318,10 @@ extension Double: PredicateValue {
 extension Sequence where Element: PredicateValue {
     public var predicateValue: Value { return .collection(self.map({ $0.predicateValue })) }
 }
+
+#if swift(>=5.5)
+
+extension Value: Sendable {}
+extension ValueType: Sendable {}
+
+#endif


### PR DESCRIPTION
I'd like to be able to pass `Predicate` structures around `async` contexts safely. The Swift compiler complains about these values not conforming to `Sendable`. I figure that, since they're all value types, conformance should be as simple as adding `Sendable` to the list of protocols to which these structures conform.

I've made conformance conditional upon the current Swift version being greater than or equal to [Swift 5.7](https://www.swift.org/blog/swift-5.7-released/), so older Swift compilers shouldn't have to worry about handling a protocol they know nothing about.